### PR TITLE
Fix race condition in java solution

### DIFF
--- a/compiled_starters/java/src/main/java/Main.java
+++ b/compiled_starters/java/src/main/java/Main.java
@@ -9,8 +9,8 @@ public class Main {
 
     // Uncomment this block to pass the first stage
     //
-    // while(true) {
-    //   try(DatagramSocket serverSocket = new DatagramSocket(2053)) {
+    // try(DatagramSocket serverSocket = new DatagramSocket(2053)) {
+    //   while(true) {
     //     final byte[] buf = new byte[512];
     //     final DatagramPacket packet = new DatagramPacket(buf, buf.length);
     //     serverSocket.receive(packet);
@@ -19,9 +19,9 @@ public class Main {
     //     final byte[] bufResponse = new byte[512];
     //     final DatagramPacket packetResponse = new DatagramPacket(bufResponse, bufResponse.length, packet.getSocketAddress());
     //     serverSocket.send(packetResponse);
-    //   } catch (IOException e) {
-    //     System.out.println("IOException: " + e.getMessage());
     //   }
+    // } catch (IOException e) {
+    //     System.out.println("IOException: " + e.getMessage());
     // }
   }
 }

--- a/solutions/java/01-init/code/src/main/java/Main.java
+++ b/solutions/java/01-init/code/src/main/java/Main.java
@@ -4,8 +4,8 @@ import java.net.DatagramSocket;
 
 public class Main {
   public static void main(String[] args){
-    while(true) {
-      try(DatagramSocket serverSocket = new DatagramSocket(2053)) {
+    try(DatagramSocket serverSocket = new DatagramSocket(2053)) {
+      while(true) {
         final byte[] buf = new byte[512];
         final DatagramPacket packet = new DatagramPacket(buf, buf.length);
         serverSocket.receive(packet);
@@ -14,9 +14,9 @@ public class Main {
         final byte[] bufResponse = new byte[512];
         final DatagramPacket packetResponse = new DatagramPacket(bufResponse, bufResponse.length, packet.getSocketAddress());
         serverSocket.send(packetResponse);
-      } catch (IOException e) {
-        System.out.println("IOException: " + e.getMessage());
       }
+    } catch (IOException e) {
+        System.out.println("IOException: " + e.getMessage());
     }
   }
 }

--- a/solutions/java/01-init/diff/src/main/java/Main.java.diff
+++ b/solutions/java/01-init/diff/src/main/java/Main.java.diff
@@ -7,8 +7,8 @@
    public static void main(String[] args){
 -    // You can use print statements as follows for debugging, they'll be visible when running tests.
 -    System.out.println("Logs from your program will appear here!");
-+    while(true) {
-+      try(DatagramSocket serverSocket = new DatagramSocket(2053)) {
++    try(DatagramSocket serverSocket = new DatagramSocket(2053)) {
++      while(true) {
 +        final byte[] buf = new byte[512];
 +        final DatagramPacket packet = new DatagramPacket(buf, buf.length);
 +        serverSocket.receive(packet);
@@ -16,8 +16,8 @@
 
 -    // Uncomment this block to pass the first stage
 -    //
--    // while(true) {
--    //   try(DatagramSocket serverSocket = new DatagramSocket(2053)) {
+-    // try(DatagramSocket serverSocket = new DatagramSocket(2053)) {
+-    //   while(true) {
 -    //     final byte[] buf = new byte[512];
 -    //     final DatagramPacket packet = new DatagramPacket(buf, buf.length);
 -    //     serverSocket.receive(packet);
@@ -26,16 +26,16 @@
 -    //     final byte[] bufResponse = new byte[512];
 -    //     final DatagramPacket packetResponse = new DatagramPacket(bufResponse, bufResponse.length, packet.getSocketAddress());
 -    //     serverSocket.send(packetResponse);
--    //   } catch (IOException e) {
--    //     System.out.println("IOException: " + e.getMessage());
 -    //   }
+-    // } catch (IOException e) {
+-    //     System.out.println("IOException: " + e.getMessage());
 -    // }
 +        final byte[] bufResponse = new byte[512];
 +        final DatagramPacket packetResponse = new DatagramPacket(bufResponse, bufResponse.length, packet.getSocketAddress());
 +        serverSocket.send(packetResponse);
-+      } catch (IOException e) {
-+        System.out.println("IOException: " + e.getMessage());
 +      }
++    } catch (IOException e) {
++        System.out.println("IOException: " + e.getMessage());
 +    }
    }
  }

--- a/starter_templates/java/src/main/java/Main.java
+++ b/starter_templates/java/src/main/java/Main.java
@@ -9,8 +9,8 @@ public class Main {
 
     // Uncomment this block to pass the first stage
     //
-    // while(true) {
-    //   try(DatagramSocket serverSocket = new DatagramSocket(2053)) {
+    // try(DatagramSocket serverSocket = new DatagramSocket(2053)) {
+    //   while(true) {
     //     final byte[] buf = new byte[512];
     //     final DatagramPacket packet = new DatagramPacket(buf, buf.length);
     //     serverSocket.receive(packet);
@@ -19,9 +19,9 @@ public class Main {
     //     final byte[] bufResponse = new byte[512];
     //     final DatagramPacket packetResponse = new DatagramPacket(bufResponse, bufResponse.length, packet.getSocketAddress());
     //     serverSocket.send(packetResponse);
-    //   } catch (IOException e) {
-    //     System.out.println("IOException: " + e.getMessage());
     //   }
+    // } catch (IOException e) {
+    //     System.out.println("IOException: " + e.getMessage());
     // }
   }
 }


### PR DESCRIPTION
Starting in stage 2 and 3, the java solution would sometimes miss a packet due to closing and reopening the socket each time.

This makes sure we only open it once