### PR TITLE
Update course-definition.yml

### DIFF
--- a/course-definition.yml
+++ b/course-definition.yml
@@ -421,7 +421,7 @@ stages:
       ```bash
       ./your_server --resolver <address>
       ```
-      * where <address> will be of the form `<ip>:<port>`
+      * where `<address>` will be of the form `<ip>:<port>`
 
       It'll then send a UDP packet (containing a DNS query) to port 2053. Your program will be responsible for forwarding DNS queries to a specified DNS server, and then returning the response to the original requester (i.e. the tester).
 


### PR DESCRIPTION
Issue with description md in "Forwarding Server" step.
Instead of showing `<address>` is showing an html tag:
![image](https://github.com/codecrafters-io/build-your-own-dns-server/assets/72663983/77eea315-5728-451f-a94a-756ff127cc07)
![image](https://github.com/codecrafters-io/build-your-own-dns-server/assets/72663983/9d7a5c34-54aa-496b-940a-4dddf4a5e9e2)
Solves #10
