### PR TITLE
Rust 1.76 upgrade

### DIFF
--- a/compiled_starters/rust/codecrafters.yml
+++ b/compiled_starters/rust/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.70
-language_pack: rust-1.70
+# Available versions: rust-1.76
+language_pack: rust-1.76

--- a/dockerfiles/rust-1.76.Dockerfile
+++ b/dockerfiles/rust-1.76.Dockerfile
@@ -1,0 +1,20 @@
+FROM rust:1.76-buster
+
+COPY Cargo.toml /app/Cargo.toml
+COPY Cargo.lock /app/Cargo.lock
+
+RUN mkdir /app/src
+RUN echo 'fn main() { println!("Hello World!"); }' > /app/src/main.rs
+
+WORKDIR /app
+RUN cargo build --release --target-dir=/tmp/codecrafters-dns-target
+
+RUN cargo clean -p dns-starter-rust --release --target-dir=/tmp/codecrafters-dns-target
+
+RUN rm -rf /app/src
+
+RUN echo "cd \${CODECRAFTERS_SUBMISSION_DIR} && cargo build --release --target-dir=/tmp/codecrafters-dns-target --manifest-path Cargo.toml" > /codecrafters-precompile.sh
+RUN chmod +x /codecrafters-precompile.sh
+
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Cargo.toml,Cargo.lock"
+

--- a/solutions/rust/01-init/code/codecrafters.yml
+++ b/solutions/rust/01-init/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.70
-language_pack: rust-1.70
+# Available versions: rust-1.76
+language_pack: rust-1.76

--- a/starter_templates/codecrafters.yml
+++ b/starter_templates/codecrafters.yml
@@ -24,8 +24,8 @@ language_pack: c-9.2
 language_pack: cpp-20
 {{/language_is_cpp}}
 {{# language_is_rust }}
-# Available versions: rust-1.70
-language_pack: rust-1.70
+# Available versions: rust-1.76
+language_pack: rust-1.76
 {{/ language_is_rust }}
 {{# language_is_java }}
 # Available versions: java-21


### PR DESCRIPTION
[CC-1043](https://linear.app/codecrafters/issue/CC-1043/update-rust-version-to-176-across-all-courses): Update Rust version used in course repositories.

Closes: CC-1043.