### PR TITLE
CC-1665: Expand Zig track to DNS Server

### DIFF
--- a/compiled_starters/zig/.codecrafters/compile.sh
+++ b/compiled_starters/zig/.codecrafters/compile.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+zig build

--- a/compiled_starters/zig/.codecrafters/run.sh
+++ b/compiled_starters/zig/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec $(dirname $0)/zig-out/bin/main "$@"
+exec "$(dirname "$0")"/zig-out/bin/main "$@"

--- a/compiled_starters/zig/.codecrafters/run.sh
+++ b/compiled_starters/zig/.codecrafters/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+exec $(dirname $0)/zig-out/bin/main "$@"

--- a/compiled_starters/zig/.gitattributes
+++ b/compiled_starters/zig/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/compiled_starters/zig/.gitignore
+++ b/compiled_starters/zig/.gitignore
@@ -1,0 +1,18 @@
+# Zig build artifacts
+main
+zig-cache/
+.zig-cache/
+zig-out/
+
+# Compiled binary output
+bin/
+!bin/.gitkeep
+
+# Ignore any .o or .h files generated during build
+*.o
+*.h
+
+# Ignore OS and editor specific files
+**/.DS_Store
+*.swp
+*~

--- a/compiled_starters/zig/README.md
+++ b/compiled_starters/zig/README.md
@@ -1,0 +1,36 @@
+![progress-banner](https://codecrafters.io/landing/images/default_progress_banners/dns-server.png)
+
+This is a starting point for Zig solutions to the
+["Build Your Own DNS server" Challenge](https://app.codecrafters.io/courses/dns-server/overview).
+
+In this challenge, you'll build a DNS server that's capable of parsing and
+creating DNS packets, responding to DNS queries, handling various record types
+and doing recursive resolve. Along the way we'll learn about the DNS protocol,
+DNS packet format, root servers, authoritative servers, forwarding servers,
+various record types (A, AAAA, CNAME, etc) and more.
+
+**Note**: If you're viewing this repo on GitHub, head over to
+[codecrafters.io](https://codecrafters.io) to try the challenge.
+
+# Passing the first stage
+
+The entry point for your `your_program.sh` implementation is in `src/main.zig`.
+Study and uncomment the relevant code, and push your changes to pass the first
+stage:
+
+```sh
+git commit -am "pass 1st stage" # any msg
+git push origin master
+```
+
+Time to move on to the next stage!
+
+# Stage 2 & beyond
+
+Note: This section is for stages 2 and beyond.
+
+1. Ensure you have `zig (0.14)` installed locally
+1. Run `./your_program.sh` to run your program, which is implemented in
+   `src/main.zig`.
+1. Commit your changes and run `git push origin master` to submit your solution
+   to CodeCrafters. Test output will be streamed to your terminal.

--- a/compiled_starters/zig/build.zig
+++ b/compiled_starters/zig/build.zig
@@ -1,0 +1,33 @@
+const std = @import("std");
+
+// Learn more about this file here: https://ziglang.org/learn/build-system
+pub fn build(b: *std.Build) void {
+    const exe = b.addExecutable(.{
+        .name = "main",
+        .root_source_file = b.path("src/main.zig"),
+        .target = b.standardTargetOptions(.{}),
+        .optimize = b.standardOptimizeOption(.{}),
+    });
+
+    // This declares intent for the executable to be installed into the
+    // standard location when the user invokes the "install" step (the default
+    // step when running `zig build`).
+    b.installArtifact(exe);
+
+    // This *creates* a Run step in the build graph, to be executed when another
+    // step is evaluated that depends on it. The next line below will establish
+    // such a dependency.
+    const run_cmd = b.addRunArtifact(exe);
+
+    // This creates a build step. It will be visible in the `zig build --help` menu,
+    // and can be selected like this: `zig build run`
+    // This will evaluate the `run` step rather than the default, which is "install".
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+
+    // This allows the user to pass arguments to the application in the build
+    // command itself, like this: `zig build run -- arg1 arg2 etc`
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+}

--- a/compiled_starters/zig/build.zig.zon
+++ b/compiled_starters/zig/build.zig.zon
@@ -1,0 +1,68 @@
+.{
+    .name = .codecrafters_dns_server,
+    .fingerprint = 0xc4ae1e93cc7c0db7, // fingerprint needs to be manually updated
+
+    // This is a [Semantic Version](https://semver.org/).
+    // In a future version of Zig it will be used for package deduplication.
+    .version = "0.0.0",
+
+    // Tracks the earliest Zig version that the package considers to be a
+    // supported use case.
+    .minimum_zig_version = "0.14.0",
+
+    // This field is optional.
+    // Each dependency must either provide a `url` and `hash`, or a `path`.
+    // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
+    // Once all dependencies are fetched, `zig build` no longer requires
+    // internet connectivity.
+    .dependencies = .{
+        // See `zig fetch --save <url>` for a command-line interface for adding dependencies.
+        //.example = .{
+        //    // When updating this field to a new URL, be sure to delete the corresponding
+        //    // `hash`, otherwise you are communicating that you expect to find the old hash at
+        //    // the new URL.
+        //    .url = "https://example.com/foo.tar.gz",
+        //
+        //    // This is computed from the file contents of the directory of files that is
+        //    // obtained after fetching `url` and applying the inclusion rules given by
+        //    // `paths`.
+        //    //
+        //    // This field is the source of truth; packages do not come from a `url`; they
+        //    // come from a `hash`. `url` is just one of many possible mirrors for how to
+        //    // obtain a package matching this `hash`.
+        //    //
+        //    // Uses the [multihash](https://multiformats.io/multihash/) format.
+        //    .hash = "...",
+        //
+        //    // When this is provided, the package is found in a directory relative to the
+        //    // build root. In this case the package's hash is irrelevant and therefore not
+        //    // computed. This field and `url` are mutually exclusive.
+        //    .path = "foo",
+
+        //    // When this is set to `true`, a package is declared to be lazily
+        //    // fetched. This makes the dependency only get fetched if it is
+        //    // actually used.
+        //    .lazy = false,
+        //},
+    },
+
+    // Specifies the set of files and directories that are included in this package.
+    // Only files and directories listed here are included in the `hash` that
+    // is computed for this package.
+    // Paths are relative to the build root. Use the empty string (`""`) to refer to
+    // the build root itself.
+    // A directory listed here means that all files within, recursively, are included.
+    .paths = .{
+        // This makes *all* files, recursively, included in this package. It is generally
+        // better to explicitly list the files and directories instead, to insure that
+        // fetching from tarballs, file system paths, and version control all result
+        // in the same contents hash.
+        "",
+        // For example...
+        //"build.zig",
+        //"build.zig.zon",
+        //"src",
+        //"LICENSE",
+        //"README.md",
+    },
+}

--- a/compiled_starters/zig/codecrafters.yml
+++ b/compiled_starters/zig/codecrafters.yml
@@ -1,0 +1,11 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: false
+
+# Use this to change the Zig version used to run your code
+# on Codecrafters.
+#
+# Available versions: zig-0.14
+language_pack: zig-0.14

--- a/compiled_starters/zig/src/main.zig
+++ b/compiled_starters/zig/src/main.zig
@@ -1,0 +1,27 @@
+const std = @import("std");
+const net = std.net;
+const posix = std.posix;
+
+pub fn main() !void {
+    const sock_fd = try posix.socket(posix.AF.INET, posix.SOCK.DGRAM, 0);
+    defer posix.close(sock_fd);
+
+    const addr = net.Address.initIp4([4]u8{ 127, 0, 0, 1 }, 2053);
+    try posix.bind(sock_fd, &addr.any, addr.getOsSockLen());
+
+    // You can use print statements as follows for debugging, they'll be visible when running tests.
+    std.debug.print("Logs from your program will appear here!\n", .{});
+
+    // Uncomment this block to pass the first stage
+    //
+    // var buf: [1024]u8 = undefined;
+    // while (true) {
+    //     var client_addr: posix.sockaddr = undefined;
+    //     var client_addr_len: posix.socklen_t = @sizeOf(posix.sockaddr);
+    //
+    //     _ = try posix.recvfrom(sock_fd, &buf, 0, &client_addr, &client_addr_len);
+    //
+    //     const response: []const u8 = "";
+    //     _ = try posix.sendto(sock_fd, response, 0, &client_addr, client_addr_len);
+    // }
+}

--- a/compiled_starters/zig/your_program.sh
+++ b/compiled_starters/zig/your_program.sh
@@ -21,4 +21,4 @@ set -e # Exit early if any commands fail
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec $(dirname $0)/zig-out/bin/main "$@"
+exec "$(dirname "$0")"/zig-out/bin/main "$@"

--- a/compiled_starters/zig/your_program.sh
+++ b/compiled_starters/zig/your_program.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# Use this script to run your program LOCALLY.
+#
+# Note: Changing this script WILL NOT affect how CodeCrafters runs your program.
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit early if any commands fail
+
+# Copied from .codecrafters/compile.sh
+#
+# - Edit this to change how your program compiles locally
+# - Edit .codecrafters/compile.sh to change how your program compiles remotely
+(
+  cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
+  zig build
+)
+
+# Copied from .codecrafters/run.sh
+#
+# - Edit this to change how your program runs locally
+# - Edit .codecrafters/run.sh to change how your program runs remotely
+exec $(dirname $0)/zig-out/bin/main "$@"

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -69,6 +69,7 @@ languages:
   - slug: "ruby"
   - slug: "rust"
   - slug: "typescript"
+  - slug: "zig"
 
 marketing:
   # Shown in the catalog.

--- a/dockerfiles/zig-0.14.Dockerfile
+++ b/dockerfiles/zig-0.14.Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM alpine:3.20
+
+RUN apk add --no-cache 'xz>=5.6' 'curl>=8.9'
+
+# Download and install Zig
+RUN curl -O https://ziglang.org/download/0.14.0/zig-linux-x86_64-0.14.0.tar.xz \
+    && tar -xf zig-linux-x86_64-0.14.0.tar.xz \
+    && mv zig-linux-x86_64-0.14.0 /usr/local/zig \
+    && rm zig-linux-x86_64-0.14.0.tar.xz
+
+# Add Zig to PATH
+ENV PATH="/usr/local/zig:${PATH}"
+
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="build.zig,build.zig.zon"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# This runs zig build
+RUN .codecrafters/compile.sh
+
+# Cache build directory
+RUN mkdir -p /app-cached
+RUN mv /app/.zig-cache /app-cached/.zig-cache || true

--- a/solutions/zig/01-ux2/code/.codecrafters/compile.sh
+++ b/solutions/zig/01-ux2/code/.codecrafters/compile.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+zig build

--- a/solutions/zig/01-ux2/code/.codecrafters/run.sh
+++ b/solutions/zig/01-ux2/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec $(dirname $0)/zig-out/bin/main "$@"
+exec "$(dirname "$0")"/zig-out/bin/main "$@"

--- a/solutions/zig/01-ux2/code/.codecrafters/run.sh
+++ b/solutions/zig/01-ux2/code/.codecrafters/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+exec $(dirname $0)/zig-out/bin/main "$@"

--- a/solutions/zig/01-ux2/code/.gitattributes
+++ b/solutions/zig/01-ux2/code/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/solutions/zig/01-ux2/code/.gitignore
+++ b/solutions/zig/01-ux2/code/.gitignore
@@ -1,0 +1,18 @@
+# Zig build artifacts
+main
+zig-cache/
+.zig-cache/
+zig-out/
+
+# Compiled binary output
+bin/
+!bin/.gitkeep
+
+# Ignore any .o or .h files generated during build
+*.o
+*.h
+
+# Ignore OS and editor specific files
+**/.DS_Store
+*.swp
+*~

--- a/solutions/zig/01-ux2/code/README.md
+++ b/solutions/zig/01-ux2/code/README.md
@@ -1,0 +1,36 @@
+![progress-banner](https://codecrafters.io/landing/images/default_progress_banners/dns-server.png)
+
+This is a starting point for Zig solutions to the
+["Build Your Own DNS server" Challenge](https://app.codecrafters.io/courses/dns-server/overview).
+
+In this challenge, you'll build a DNS server that's capable of parsing and
+creating DNS packets, responding to DNS queries, handling various record types
+and doing recursive resolve. Along the way we'll learn about the DNS protocol,
+DNS packet format, root servers, authoritative servers, forwarding servers,
+various record types (A, AAAA, CNAME, etc) and more.
+
+**Note**: If you're viewing this repo on GitHub, head over to
+[codecrafters.io](https://codecrafters.io) to try the challenge.
+
+# Passing the first stage
+
+The entry point for your `your_program.sh` implementation is in `src/main.zig`.
+Study and uncomment the relevant code, and push your changes to pass the first
+stage:
+
+```sh
+git commit -am "pass 1st stage" # any msg
+git push origin master
+```
+
+Time to move on to the next stage!
+
+# Stage 2 & beyond
+
+Note: This section is for stages 2 and beyond.
+
+1. Ensure you have `zig (0.14)` installed locally
+1. Run `./your_program.sh` to run your program, which is implemented in
+   `src/main.zig`.
+1. Commit your changes and run `git push origin master` to submit your solution
+   to CodeCrafters. Test output will be streamed to your terminal.

--- a/solutions/zig/01-ux2/code/build.zig
+++ b/solutions/zig/01-ux2/code/build.zig
@@ -1,0 +1,33 @@
+const std = @import("std");
+
+// Learn more about this file here: https://ziglang.org/learn/build-system
+pub fn build(b: *std.Build) void {
+    const exe = b.addExecutable(.{
+        .name = "main",
+        .root_source_file = b.path("src/main.zig"),
+        .target = b.standardTargetOptions(.{}),
+        .optimize = b.standardOptimizeOption(.{}),
+    });
+
+    // This declares intent for the executable to be installed into the
+    // standard location when the user invokes the "install" step (the default
+    // step when running `zig build`).
+    b.installArtifact(exe);
+
+    // This *creates* a Run step in the build graph, to be executed when another
+    // step is evaluated that depends on it. The next line below will establish
+    // such a dependency.
+    const run_cmd = b.addRunArtifact(exe);
+
+    // This creates a build step. It will be visible in the `zig build --help` menu,
+    // and can be selected like this: `zig build run`
+    // This will evaluate the `run` step rather than the default, which is "install".
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+
+    // This allows the user to pass arguments to the application in the build
+    // command itself, like this: `zig build run -- arg1 arg2 etc`
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+}

--- a/solutions/zig/01-ux2/code/build.zig.zon
+++ b/solutions/zig/01-ux2/code/build.zig.zon
@@ -1,0 +1,68 @@
+.{
+    .name = .codecrafters_dns_server,
+    .fingerprint = 0xc4ae1e93cc7c0db7, // fingerprint needs to be manually updated
+
+    // This is a [Semantic Version](https://semver.org/).
+    // In a future version of Zig it will be used for package deduplication.
+    .version = "0.0.0",
+
+    // Tracks the earliest Zig version that the package considers to be a
+    // supported use case.
+    .minimum_zig_version = "0.14.0",
+
+    // This field is optional.
+    // Each dependency must either provide a `url` and `hash`, or a `path`.
+    // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
+    // Once all dependencies are fetched, `zig build` no longer requires
+    // internet connectivity.
+    .dependencies = .{
+        // See `zig fetch --save <url>` for a command-line interface for adding dependencies.
+        //.example = .{
+        //    // When updating this field to a new URL, be sure to delete the corresponding
+        //    // `hash`, otherwise you are communicating that you expect to find the old hash at
+        //    // the new URL.
+        //    .url = "https://example.com/foo.tar.gz",
+        //
+        //    // This is computed from the file contents of the directory of files that is
+        //    // obtained after fetching `url` and applying the inclusion rules given by
+        //    // `paths`.
+        //    //
+        //    // This field is the source of truth; packages do not come from a `url`; they
+        //    // come from a `hash`. `url` is just one of many possible mirrors for how to
+        //    // obtain a package matching this `hash`.
+        //    //
+        //    // Uses the [multihash](https://multiformats.io/multihash/) format.
+        //    .hash = "...",
+        //
+        //    // When this is provided, the package is found in a directory relative to the
+        //    // build root. In this case the package's hash is irrelevant and therefore not
+        //    // computed. This field and `url` are mutually exclusive.
+        //    .path = "foo",
+
+        //    // When this is set to `true`, a package is declared to be lazily
+        //    // fetched. This makes the dependency only get fetched if it is
+        //    // actually used.
+        //    .lazy = false,
+        //},
+    },
+
+    // Specifies the set of files and directories that are included in this package.
+    // Only files and directories listed here are included in the `hash` that
+    // is computed for this package.
+    // Paths are relative to the build root. Use the empty string (`""`) to refer to
+    // the build root itself.
+    // A directory listed here means that all files within, recursively, are included.
+    .paths = .{
+        // This makes *all* files, recursively, included in this package. It is generally
+        // better to explicitly list the files and directories instead, to insure that
+        // fetching from tarballs, file system paths, and version control all result
+        // in the same contents hash.
+        "",
+        // For example...
+        //"build.zig",
+        //"build.zig.zon",
+        //"src",
+        //"LICENSE",
+        //"README.md",
+    },
+}

--- a/solutions/zig/01-ux2/code/codecrafters.yml
+++ b/solutions/zig/01-ux2/code/codecrafters.yml
@@ -1,0 +1,11 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: false
+
+# Use this to change the Zig version used to run your code
+# on Codecrafters.
+#
+# Available versions: zig-0.14
+language_pack: zig-0.14

--- a/solutions/zig/01-ux2/code/src/main.zig
+++ b/solutions/zig/01-ux2/code/src/main.zig
@@ -1,0 +1,22 @@
+const std = @import("std");
+const net = std.net;
+const posix = std.posix;
+
+pub fn main() !void {
+    const sock_fd = try posix.socket(posix.AF.INET, posix.SOCK.DGRAM, 0);
+    defer posix.close(sock_fd);
+
+    const addr = net.Address.initIp4([4]u8{ 127, 0, 0, 1 }, 2053);
+    try posix.bind(sock_fd, &addr.any, addr.getOsSockLen());
+
+    var buf: [1024]u8 = undefined;
+    while (true) {
+        var client_addr: posix.sockaddr = undefined;
+        var client_addr_len: posix.socklen_t = @sizeOf(posix.sockaddr);
+
+        _ = try posix.recvfrom(sock_fd, &buf, 0, &client_addr, &client_addr_len);
+
+        const response: []const u8 = "";
+        _ = try posix.sendto(sock_fd, response, 0, &client_addr, client_addr_len);
+    }
+}

--- a/solutions/zig/01-ux2/code/your_program.sh
+++ b/solutions/zig/01-ux2/code/your_program.sh
@@ -21,4 +21,4 @@ set -e # Exit early if any commands fail
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec $(dirname $0)/zig-out/bin/main "$@"
+exec "$(dirname "$0")"/zig-out/bin/main "$@"

--- a/solutions/zig/01-ux2/code/your_program.sh
+++ b/solutions/zig/01-ux2/code/your_program.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# Use this script to run your program LOCALLY.
+#
+# Note: Changing this script WILL NOT affect how CodeCrafters runs your program.
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit early if any commands fail
+
+# Copied from .codecrafters/compile.sh
+#
+# - Edit this to change how your program compiles locally
+# - Edit .codecrafters/compile.sh to change how your program compiles remotely
+(
+  cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
+  zig build
+)
+
+# Copied from .codecrafters/run.sh
+#
+# - Edit this to change how your program runs locally
+# - Edit .codecrafters/run.sh to change how your program runs remotely
+exec $(dirname $0)/zig-out/bin/main "$@"

--- a/solutions/zig/01-ux2/diff/src/main.zig.diff
+++ b/solutions/zig/01-ux2/diff/src/main.zig.diff
@@ -1,0 +1,37 @@
+@@ -1,27 +1,22 @@
+ const std = @import("std");
+ const net = std.net;
+ const posix = std.posix;
+
+ pub fn main() !void {
+     const sock_fd = try posix.socket(posix.AF.INET, posix.SOCK.DGRAM, 0);
+     defer posix.close(sock_fd);
+
+     const addr = net.Address.initIp4([4]u8{ 127, 0, 0, 1 }, 2053);
+     try posix.bind(sock_fd, &addr.any, addr.getOsSockLen());
+
+-    // You can use print statements as follows for debugging, they'll be visible when running tests.
+-    std.debug.print("Logs from your program will appear here!\n", .{});
++    var buf: [1024]u8 = undefined;
++    while (true) {
++        var client_addr: posix.sockaddr = undefined;
++        var client_addr_len: posix.socklen_t = @sizeOf(posix.sockaddr);
+
+-    // Uncomment this block to pass the first stage
+-    //
+-    // var buf: [1024]u8 = undefined;
+-    // while (true) {
+-    //     var client_addr: posix.sockaddr = undefined;
+-    //     var client_addr_len: posix.socklen_t = @sizeOf(posix.sockaddr);
+-    //
+-    //     _ = try posix.recvfrom(sock_fd, &buf, 0, &client_addr, &client_addr_len);
+-    //
+-    //     const response: []const u8 = "";
+-    //     _ = try posix.sendto(sock_fd, response, 0, &client_addr, client_addr_len);
+-    // }
++        _ = try posix.recvfrom(sock_fd, &buf, 0, &client_addr, &client_addr_len);
++
++        const response: []const u8 = "";
++        _ = try posix.sendto(sock_fd, response, 0, &client_addr, client_addr_len);
++    }
+ }

--- a/solutions/zig/01-ux2/explanation.md
+++ b/solutions/zig/01-ux2/explanation.md
@@ -1,0 +1,26 @@
+The entry point for your DNS Server implementation is in `src/main.zig`.
+
+Study and uncomment the relevant code: 
+
+```zig
+// Uncomment this block to pass the first stage
+
+var buf: [1024]u8 = undefined;
+while (true) {
+    var client_addr: posix.sockaddr = undefined;
+    var client_addr_len: posix.socklen_t = @sizeOf(posix.sockaddr);
+
+    _ = try posix.recvfrom(sock_fd, &buf, 0, &client_addr, &client_addr_len);
+
+    const response: []const u8 = "";
+    _ = try posix.sendto(sock_fd, response, 0, &client_addr, client_addr_len);
+}
+```
+
+Push your changes to pass the first stage:
+
+```
+git add .
+git commit -m "pass 1st stage" # any msg
+git push origin master
+```

--- a/starter_templates/zig/code/.codecrafters/compile.sh
+++ b/starter_templates/zig/code/.codecrafters/compile.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+zig build

--- a/starter_templates/zig/code/.codecrafters/run.sh
+++ b/starter_templates/zig/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec $(dirname $0)/zig-out/bin/main "$@"
+exec "$(dirname "$0")"/zig-out/bin/main "$@"

--- a/starter_templates/zig/code/.codecrafters/run.sh
+++ b/starter_templates/zig/code/.codecrafters/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+exec $(dirname $0)/zig-out/bin/main "$@"

--- a/starter_templates/zig/code/.gitignore
+++ b/starter_templates/zig/code/.gitignore
@@ -1,0 +1,18 @@
+# Zig build artifacts
+main
+zig-cache/
+.zig-cache/
+zig-out/
+
+# Compiled binary output
+bin/
+!bin/.gitkeep
+
+# Ignore any .o or .h files generated during build
+*.o
+*.h
+
+# Ignore OS and editor specific files
+**/.DS_Store
+*.swp
+*~

--- a/starter_templates/zig/code/build.zig
+++ b/starter_templates/zig/code/build.zig
@@ -1,0 +1,33 @@
+const std = @import("std");
+
+// Learn more about this file here: https://ziglang.org/learn/build-system
+pub fn build(b: *std.Build) void {
+    const exe = b.addExecutable(.{
+        .name = "main",
+        .root_source_file = b.path("src/main.zig"),
+        .target = b.standardTargetOptions(.{}),
+        .optimize = b.standardOptimizeOption(.{}),
+    });
+
+    // This declares intent for the executable to be installed into the
+    // standard location when the user invokes the "install" step (the default
+    // step when running `zig build`).
+    b.installArtifact(exe);
+
+    // This *creates* a Run step in the build graph, to be executed when another
+    // step is evaluated that depends on it. The next line below will establish
+    // such a dependency.
+    const run_cmd = b.addRunArtifact(exe);
+
+    // This creates a build step. It will be visible in the `zig build --help` menu,
+    // and can be selected like this: `zig build run`
+    // This will evaluate the `run` step rather than the default, which is "install".
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+
+    // This allows the user to pass arguments to the application in the build
+    // command itself, like this: `zig build run -- arg1 arg2 etc`
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+}

--- a/starter_templates/zig/code/build.zig.zon
+++ b/starter_templates/zig/code/build.zig.zon
@@ -1,0 +1,68 @@
+.{
+    .name = .codecrafters_dns_server,
+    .fingerprint = 0xc4ae1e93cc7c0db7, // fingerprint needs to be manually updated
+
+    // This is a [Semantic Version](https://semver.org/).
+    // In a future version of Zig it will be used for package deduplication.
+    .version = "0.0.0",
+
+    // Tracks the earliest Zig version that the package considers to be a
+    // supported use case.
+    .minimum_zig_version = "0.14.0",
+
+    // This field is optional.
+    // Each dependency must either provide a `url` and `hash`, or a `path`.
+    // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
+    // Once all dependencies are fetched, `zig build` no longer requires
+    // internet connectivity.
+    .dependencies = .{
+        // See `zig fetch --save <url>` for a command-line interface for adding dependencies.
+        //.example = .{
+        //    // When updating this field to a new URL, be sure to delete the corresponding
+        //    // `hash`, otherwise you are communicating that you expect to find the old hash at
+        //    // the new URL.
+        //    .url = "https://example.com/foo.tar.gz",
+        //
+        //    // This is computed from the file contents of the directory of files that is
+        //    // obtained after fetching `url` and applying the inclusion rules given by
+        //    // `paths`.
+        //    //
+        //    // This field is the source of truth; packages do not come from a `url`; they
+        //    // come from a `hash`. `url` is just one of many possible mirrors for how to
+        //    // obtain a package matching this `hash`.
+        //    //
+        //    // Uses the [multihash](https://multiformats.io/multihash/) format.
+        //    .hash = "...",
+        //
+        //    // When this is provided, the package is found in a directory relative to the
+        //    // build root. In this case the package's hash is irrelevant and therefore not
+        //    // computed. This field and `url` are mutually exclusive.
+        //    .path = "foo",
+
+        //    // When this is set to `true`, a package is declared to be lazily
+        //    // fetched. This makes the dependency only get fetched if it is
+        //    // actually used.
+        //    .lazy = false,
+        //},
+    },
+
+    // Specifies the set of files and directories that are included in this package.
+    // Only files and directories listed here are included in the `hash` that
+    // is computed for this package.
+    // Paths are relative to the build root. Use the empty string (`""`) to refer to
+    // the build root itself.
+    // A directory listed here means that all files within, recursively, are included.
+    .paths = .{
+        // This makes *all* files, recursively, included in this package. It is generally
+        // better to explicitly list the files and directories instead, to insure that
+        // fetching from tarballs, file system paths, and version control all result
+        // in the same contents hash.
+        "",
+        // For example...
+        //"build.zig",
+        //"build.zig.zon",
+        //"src",
+        //"LICENSE",
+        //"README.md",
+    },
+}

--- a/starter_templates/zig/code/src/main.zig
+++ b/starter_templates/zig/code/src/main.zig
@@ -1,0 +1,27 @@
+const std = @import("std");
+const net = std.net;
+const posix = std.posix;
+
+pub fn main() !void {
+    const sock_fd = try posix.socket(posix.AF.INET, posix.SOCK.DGRAM, 0);
+    defer posix.close(sock_fd);
+
+    const addr = net.Address.initIp4([4]u8{ 127, 0, 0, 1 }, 2053);
+    try posix.bind(sock_fd, &addr.any, addr.getOsSockLen());
+
+    // You can use print statements as follows for debugging, they'll be visible when running tests.
+    std.debug.print("Logs from your program will appear here!\n", .{});
+
+    // Uncomment this block to pass the first stage
+    //
+    // var buf: [1024]u8 = undefined;
+    // while (true) {
+    //     var client_addr: posix.sockaddr = undefined;
+    //     var client_addr_len: posix.socklen_t = @sizeOf(posix.sockaddr);
+    //
+    //     _ = try posix.recvfrom(sock_fd, &buf, 0, &client_addr, &client_addr_len);
+    //
+    //     const response: []const u8 = "";
+    //     _ = try posix.sendto(sock_fd, response, 0, &client_addr, client_addr_len);
+    // }
+}

--- a/starter_templates/zig/config.yml
+++ b/starter_templates/zig/config.yml
@@ -1,0 +1,3 @@
+attributes:
+  required_executable: zig (0.14)
+  user_editable_file: src/main.zig


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added comprehensive support for the Zig programming language with new build and execution scripts, including `compile.sh` and `run.sh`.
  - Introduced configuration files for dependency management and language version selection, including `.gitattributes`, `.gitignore`, and `codecrafters.yml`.
  - Implemented a basic UDP socket server in the `main.zig` file for handling client communications.

- **Documentation**
  - Provided detailed instructions and overview guides for the DNS server challenge, ensuring clear guidance for users.

- **Chores**
  - Updated file exclusion and normalization settings to maintain consistency and reduce build artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->