### PR TITLE
[DNS] CC-1745: Upgrade Bun to v1.2, Rust to v1.86

### DIFF
--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -29,7 +29,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.85)` installed locally
+1. Ensure you have `cargo (1.87)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -29,7 +29,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.87)` installed locally
+1. Ensure you have `cargo (1.86)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/compiled_starters/rust/codecrafters.yml
+++ b/compiled_starters/rust/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.87
-language_pack: rust-1.87
+# Available versions: rust-1.86
+language_pack: rust-1.86

--- a/compiled_starters/rust/codecrafters.yml
+++ b/compiled_starters/rust/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.85
-language_pack: rust-1.85
+# Available versions: rust-1.87
+language_pack: rust-1.87

--- a/compiled_starters/typescript/README.md
+++ b/compiled_starters/typescript/README.md
@@ -29,7 +29,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `bun (1.1)` installed locally
+1. Ensure you have `bun (1.2)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.ts`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/compiled_starters/typescript/codecrafters.yml
+++ b/compiled_starters/typescript/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the TypeScript version used to run your code
 # on Codecrafters.
 #
-# Available versions: bun-1.1
-language_pack: bun-1.1
+# Available versions: bun-1.2
+language_pack: bun-1.2

--- a/dockerfiles/bun-1.2.Dockerfile
+++ b/dockerfiles/bun-1.2.Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM oven/bun:1.2-alpine
+
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="package.json,bun.lockb"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# For reproducible builds.
+# This will install the exact versions of each package specified in the lockfile.
+# If package.json disagrees with bun.lockb, Bun will exit with an error. The lockfile will not be updated.
+RUN bun install --frozen-lockfile
+
+# If the node_modules directory exists, move it to /app-cached
+RUN mkdir -p /app-cached
+RUN if [ -d "/app/node_modules" ]; then mv /app/node_modules /app-cached; fi

--- a/dockerfiles/rust-1.86.Dockerfile
+++ b/dockerfiles/rust-1.86.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7-labs
-FROM rust:1.87-bookworm
+FROM rust:1.86-bookworm
 
 # Rebuild the container if these files change
 ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Cargo.toml,Cargo.lock"

--- a/dockerfiles/rust-1.87.Dockerfile
+++ b/dockerfiles/rust-1.87.Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM rust:1.87-bookworm
+
+# Rebuild the container if these files change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Cargo.toml,Cargo.lock"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# This runs cargo build
+RUN .codecrafters/compile.sh

--- a/solutions/rust/01-ux2/code/README.md
+++ b/solutions/rust/01-ux2/code/README.md
@@ -29,7 +29,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.85)` installed locally
+1. Ensure you have `cargo (1.87)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/solutions/rust/01-ux2/code/README.md
+++ b/solutions/rust/01-ux2/code/README.md
@@ -29,7 +29,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.87)` installed locally
+1. Ensure you have `cargo (1.86)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/solutions/rust/01-ux2/code/codecrafters.yml
+++ b/solutions/rust/01-ux2/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.87
-language_pack: rust-1.87
+# Available versions: rust-1.86
+language_pack: rust-1.86

--- a/solutions/rust/01-ux2/code/codecrafters.yml
+++ b/solutions/rust/01-ux2/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.85
-language_pack: rust-1.85
+# Available versions: rust-1.87
+language_pack: rust-1.87

--- a/solutions/typescript/01-ux2/code/README.md
+++ b/solutions/typescript/01-ux2/code/README.md
@@ -29,7 +29,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `bun (1.1)` installed locally
+1. Ensure you have `bun (1.2)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.ts`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/typescript/01-ux2/code/codecrafters.yml
+++ b/solutions/typescript/01-ux2/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the TypeScript version used to run your code
 # on Codecrafters.
 #
-# Available versions: bun-1.1
-language_pack: bun-1.1
+# Available versions: bun-1.2
+language_pack: bun-1.2

--- a/starter_templates/rust/config.yml
+++ b/starter_templates/rust/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: cargo (1.87)
+  required_executable: cargo (1.86)
   user_editable_file: src/main.rs

--- a/starter_templates/rust/config.yml
+++ b/starter_templates/rust/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: cargo (1.85)
+  required_executable: cargo (1.87)
   user_editable_file: src/main.rs

--- a/starter_templates/typescript/config.yml
+++ b/starter_templates/typescript/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: bun (1.1)
+  required_executable: bun (1.2)
   user_editable_file: app/main.ts


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new Dockerfiles for Rust 1.87 and Bun 1.2 environments, improving support for updated language versions.

- **Documentation**
  - Updated documentation and configuration files to require Rust 1.87 and Bun 1.2 for relevant projects.

- **Chores**
  - Updated configuration files to reflect new minimum version requirements for Rust (1.87) and Bun (1.2).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->