### PR TITLE
CC-2191: Upgrade Ruby to v4

### DIFF
--- a/compiled_starters/ruby/Gemfile.lock
+++ b/compiled_starters/ruby/Gemfile.lock
@@ -6,9 +6,11 @@ PLATFORMS
   aarch64-linux-musl
   arm64-darwin-21
   arm64-darwin-23
+  arm64-darwin-25
   x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
 
 BUNDLED WITH
-   2.5.6
+  4.0.10

--- a/solutions/ruby/01-ux2/code/Gemfile.lock
+++ b/solutions/ruby/01-ux2/code/Gemfile.lock
@@ -6,9 +6,11 @@ PLATFORMS
   aarch64-linux-musl
   arm64-darwin-21
   arm64-darwin-23
+  arm64-darwin-25
   x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
 
 BUNDLED WITH
-   2.5.6
+  4.0.10

--- a/starter_templates/ruby/code/Gemfile.lock
+++ b/starter_templates/ruby/code/Gemfile.lock
@@ -6,9 +6,11 @@ PLATFORMS
   aarch64-linux-musl
   arm64-darwin-21
   arm64-darwin-23
+  arm64-darwin-25
   x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
 
 BUNDLED WITH
-   2.5.6
+  4.0.10


### PR DESCRIPTION
CC-2191: Upgrade Ruby to v4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only updates; main risk is CI/build differences if environments aren’t on Bundler `4.0.10` or need the newly listed platforms.
> 
> **Overview**
> Updates the Ruby starter/solution `Gemfile.lock` files to **Bundler `4.0.10`** (from `2.5.6`).
> 
> Expands the lockfile `PLATFORMS` to include `arm64-darwin-25` and `x86_64-linux-musl`, improving compatibility across newer macOS and musl-based Linux environments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 673c2de27d72b06316b09970647e3b3484eb6e11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->