### PR TITLE
CC-2223: Add PHP to DNS server challenge

### DIFF
--- a/compiled_starters/php/.codecrafters/compile.sh
+++ b/compiled_starters/php/.codecrafters/compile.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+# (This file is empty since PHP programs don't use a compile step)

--- a/compiled_starters/php/.codecrafters/run.sh
+++ b/compiled_starters/php/.codecrafters/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+SCRIPT_DIR="$(dirname "$0")"
+exec php "$SCRIPT_DIR/app/main.php" "$@"

--- a/compiled_starters/php/.gitattributes
+++ b/compiled_starters/php/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/compiled_starters/php/README.md
+++ b/compiled_starters/php/README.md
@@ -1,0 +1,36 @@
+![progress-banner](https://codecrafters.io/landing/images/default_progress_banners/dns-server.png)
+
+This is a starting point for PHP solutions to the
+["Build Your Own DNS server" Challenge](https://app.codecrafters.io/courses/dns-server/overview).
+
+In this challenge, you'll build a DNS server that's capable of parsing and
+creating DNS packets, responding to DNS queries, handling various record types
+and doing recursive resolve. Along the way we'll learn about the DNS protocol,
+DNS packet format, root servers, authoritative servers, forwarding servers,
+various record types (A, AAAA, CNAME, etc) and more.
+
+**Note**: If you're viewing this repo on GitHub, head over to
+[codecrafters.io](https://codecrafters.io) to try the challenge.
+
+# Passing the first stage
+
+The entry point for your `your_program.sh` implementation is in `app/main.php`.
+Study and uncomment the relevant code, and push your changes to pass the first
+stage:
+
+```sh
+git commit -am "pass 1st stage" # any msg
+git push origin master
+```
+
+Time to move on to the next stage!
+
+# Stage 2 & beyond
+
+Note: This section is for stages 2 and beyond.
+
+1. Ensure you have `php (8.5)` installed locally
+1. Run `./your_program.sh` to run your program, which is implemented in
+   `app/main.php`.
+1. Commit your changes and run `git push origin master` to submit your solution
+   to CodeCrafters. Test output will be streamed to your terminal.

--- a/compiled_starters/php/app/main.php
+++ b/compiled_starters/php/app/main.php
@@ -1,0 +1,25 @@
+<?php
+error_reporting(E_ALL);
+
+$udp_socket = socket_create(AF_INET, SOCK_DGRAM, SOL_UDP);
+
+// Since the tester restarts your program quite often, setting SO_REUSEADDR
+// ensures that we don't run into 'Address already in use' errors
+socket_set_option($udp_socket, SOL_SOCKET, SO_REUSEADDR, 1);
+
+socket_bind($udp_socket, '127.0.0.1', 2053);
+
+// You can use print statements as follows for debugging, they'll be visible when running tests.
+fwrite(STDERR, "Logs from your program will appear here!\n");
+
+// TODO: Uncomment the code below to pass the first stage
+// 
+// while (true) {
+//     $buf = $from = '';
+//     $port = 0;
+//     if (@socket_recvfrom($udp_socket, $buf, 512, 0, $from, $port) === false) {
+//         fwrite(STDERR, 'Error receiving data: ' . socket_strerror(socket_last_error($udp_socket)) . "\n");
+//         break;
+//     }
+//     socket_sendto($udp_socket, '', 0, 0, $from, $port);
+// }

--- a/compiled_starters/php/codecrafters.yml
+++ b/compiled_starters/php/codecrafters.yml
@@ -1,0 +1,11 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: false
+
+# Use this to change the PHP version used to run your code
+# on Codecrafters.
+#
+# Available versions: php-8.5
+buildpack: php-8.5

--- a/compiled_starters/php/your_program.sh
+++ b/compiled_starters/php/your_program.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# Use this script to run your program LOCALLY.
+#
+# Note: Changing this script WILL NOT affect how CodeCrafters runs your program.
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit early if any commands fail
+
+# Copied from .codecrafters/run.sh
+#
+# - Edit this to change how your program runs locally
+# - Edit .codecrafters/run.sh to change how your program runs remotely
+SCRIPT_DIR="$(dirname "$0")"
+exec php "$SCRIPT_DIR/app/main.php" "$@"

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -66,6 +66,7 @@ languages:
   - slug: "java"
   - slug: "javascript"
   - slug: "kotlin"
+  - slug: "php"
   - slug: "python"
   - slug: "ruby"
   - slug: "rust"

--- a/dockerfiles/php-8.5.Dockerfile
+++ b/dockerfiles/php-8.5.Dockerfile
@@ -1,0 +1,7 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM php:8.5-cli-alpine3.22
+
+# For ext-sockets installation
+RUN apk add linux-headers=~6.14.2-r0 --no-cache
+
+RUN docker-php-ext-install pcntl sockets

--- a/solutions/php/01-ux2/code/.codecrafters/compile.sh
+++ b/solutions/php/01-ux2/code/.codecrafters/compile.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+# (This file is empty since PHP programs don't use a compile step)

--- a/solutions/php/01-ux2/code/.codecrafters/run.sh
+++ b/solutions/php/01-ux2/code/.codecrafters/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+SCRIPT_DIR="$(dirname "$0")"
+exec php "$SCRIPT_DIR/app/main.php" "$@"

--- a/solutions/php/01-ux2/code/.gitattributes
+++ b/solutions/php/01-ux2/code/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/solutions/php/01-ux2/code/README.md
+++ b/solutions/php/01-ux2/code/README.md
@@ -1,0 +1,36 @@
+![progress-banner](https://codecrafters.io/landing/images/default_progress_banners/dns-server.png)
+
+This is a starting point for PHP solutions to the
+["Build Your Own DNS server" Challenge](https://app.codecrafters.io/courses/dns-server/overview).
+
+In this challenge, you'll build a DNS server that's capable of parsing and
+creating DNS packets, responding to DNS queries, handling various record types
+and doing recursive resolve. Along the way we'll learn about the DNS protocol,
+DNS packet format, root servers, authoritative servers, forwarding servers,
+various record types (A, AAAA, CNAME, etc) and more.
+
+**Note**: If you're viewing this repo on GitHub, head over to
+[codecrafters.io](https://codecrafters.io) to try the challenge.
+
+# Passing the first stage
+
+The entry point for your `your_program.sh` implementation is in `app/main.php`.
+Study and uncomment the relevant code, and push your changes to pass the first
+stage:
+
+```sh
+git commit -am "pass 1st stage" # any msg
+git push origin master
+```
+
+Time to move on to the next stage!
+
+# Stage 2 & beyond
+
+Note: This section is for stages 2 and beyond.
+
+1. Ensure you have `php (8.5)` installed locally
+1. Run `./your_program.sh` to run your program, which is implemented in
+   `app/main.php`.
+1. Commit your changes and run `git push origin master` to submit your solution
+   to CodeCrafters. Test output will be streamed to your terminal.

--- a/solutions/php/01-ux2/code/app/main.php
+++ b/solutions/php/01-ux2/code/app/main.php
@@ -1,0 +1,20 @@
+<?php
+error_reporting(E_ALL);
+
+$udp_socket = socket_create(AF_INET, SOCK_DGRAM, SOL_UDP);
+
+// Since the tester restarts your program quite often, setting SO_REUSEADDR
+// ensures that we don't run into 'Address already in use' errors
+socket_set_option($udp_socket, SOL_SOCKET, SO_REUSEADDR, 1);
+
+socket_bind($udp_socket, '127.0.0.1', 2053);
+
+while (true) {
+    $buf = $from = '';
+    $port = 0;
+    if (@socket_recvfrom($udp_socket, $buf, 512, 0, $from, $port) === false) {
+        fwrite(STDERR, 'Error receiving data: ' . socket_strerror(socket_last_error($udp_socket)) . "\n");
+        break;
+    }
+    socket_sendto($udp_socket, '', 0, 0, $from, $port);
+}

--- a/solutions/php/01-ux2/code/codecrafters.yml
+++ b/solutions/php/01-ux2/code/codecrafters.yml
@@ -1,0 +1,11 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: false
+
+# Use this to change the PHP version used to run your code
+# on Codecrafters.
+#
+# Available versions: php-8.5
+buildpack: php-8.5

--- a/solutions/php/01-ux2/code/your_program.sh
+++ b/solutions/php/01-ux2/code/your_program.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# Use this script to run your program LOCALLY.
+#
+# Note: Changing this script WILL NOT affect how CodeCrafters runs your program.
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit early if any commands fail
+
+# Copied from .codecrafters/run.sh
+#
+# - Edit this to change how your program runs locally
+# - Edit .codecrafters/run.sh to change how your program runs remotely
+SCRIPT_DIR="$(dirname "$0")"
+exec php "$SCRIPT_DIR/app/main.php" "$@"

--- a/solutions/php/01-ux2/diff/app/main.php.diff
+++ b/solutions/php/01-ux2/diff/app/main.php.diff
@@ -1,0 +1,35 @@
+@@ -1,25 +1,20 @@
+ <?php
+ error_reporting(E_ALL);
+
+ $udp_socket = socket_create(AF_INET, SOCK_DGRAM, SOL_UDP);
+
+ // Since the tester restarts your program quite often, setting SO_REUSEADDR
+ // ensures that we don't run into 'Address already in use' errors
+ socket_set_option($udp_socket, SOL_SOCKET, SO_REUSEADDR, 1);
+
+ socket_bind($udp_socket, '127.0.0.1', 2053);
+
+-// You can use print statements as follows for debugging, they'll be visible when running tests.
+-fwrite(STDERR, "Logs from your program will appear here!\n");
+-
+-// TODO: Uncomment the code below to pass the first stage
+-// 
+-// while (true) {
+-//     $buf = $from = '';
+-//     $port = 0;
+-//     if (@socket_recvfrom($udp_socket, $buf, 512, 0, $from, $port) === false) {
+-//         fwrite(STDERR, 'Error receiving data: ' . socket_strerror(socket_last_error($udp_socket)) . "\n");
+-//         break;
+-//     }
+-//     socket_sendto($udp_socket, '', 0, 0, $from, $port);
+-// }
++while (true) {
++    $buf = $from = '';
++    $port = 0;
++    if (@socket_recvfrom($udp_socket, $buf, 512, 0, $from, $port) === false) {
++        fwrite(STDERR, 'Error receiving data: ' . socket_strerror(socket_last_error($udp_socket)) . "\n");
++        break;
++    }
++    socket_sendto($udp_socket, '', 0, 0, $from, $port);
++}

--- a/starter_templates/php/code/.codecrafters/compile.sh
+++ b/starter_templates/php/code/.codecrafters/compile.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+# (This file is empty since PHP programs don't use a compile step)

--- a/starter_templates/php/code/.codecrafters/run.sh
+++ b/starter_templates/php/code/.codecrafters/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+SCRIPT_DIR="$(dirname "$0")"
+exec php "$SCRIPT_DIR/app/main.php" "$@"

--- a/starter_templates/php/code/app/main.php
+++ b/starter_templates/php/code/app/main.php
@@ -1,0 +1,25 @@
+<?php
+error_reporting(E_ALL);
+
+$udp_socket = socket_create(AF_INET, SOCK_DGRAM, SOL_UDP);
+
+// Since the tester restarts your program quite often, setting SO_REUSEADDR
+// ensures that we don't run into 'Address already in use' errors
+socket_set_option($udp_socket, SOL_SOCKET, SO_REUSEADDR, 1);
+
+socket_bind($udp_socket, '127.0.0.1', 2053);
+
+// You can use print statements as follows for debugging, they'll be visible when running tests.
+fwrite(STDERR, "Logs from your program will appear here!\n");
+
+// TODO: Uncomment the code below to pass the first stage
+// 
+// while (true) {
+//     $buf = $from = '';
+//     $port = 0;
+//     if (@socket_recvfrom($udp_socket, $buf, 512, 0, $from, $port) === false) {
+//         fwrite(STDERR, 'Error receiving data: ' . socket_strerror(socket_last_error($udp_socket)) . "\n");
+//         break;
+//     }
+//     socket_sendto($udp_socket, '', 0, 0, $from, $port);
+// }

--- a/starter_templates/php/config.yml
+++ b/starter_templates/php/config.yml
@@ -1,0 +1,3 @@
+attributes:
+  required_executable: "php (8.5)"
+  user_editable_file: "app/main.php"


### PR DESCRIPTION
- Created starter template files including README, configuration, and scripts for local execution.
- Added initial PHP application structure with socket setup for DNS server functionality.
- Included Codecrafters configuration files for build and run processes.
- Established a sample solution for the "Build Your Own DNS server" challenge with necessary files and instructions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly new language scaffolding (templates, scripts, Dockerfile) with minimal impact to existing course logic beyond enabling an additional language.
> 
> **Overview**
> Adds **PHP 8.5 support** to the DNS server challenge by registering `php` in `course-definition.yml` and introducing a `php-8.5` Docker buildpack with required extensions (`sockets`, `pcntl`).
> 
> Introduces new PHP starter/compiled starter assets (README, `.codecrafters` `compile.sh`/`run.sh`, `your_program.sh`, `codecrafters.yml`, and `app/main.php`) plus a corresponding stage-1 reference solution that binds UDP `127.0.0.1:2053` and echoes empty responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5621e742d3e424a5003f11fcc4b4de8c720f775d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->