### PR TITLE
https://linear.app/codecrafters/issue/CC-2159/replace-git-commands-in-readmes-as-cc-submit

### DIFF
--- a/compiled_starters/c/README.md
+++ b/compiled_starters/c/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `src/main.c`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/cpp/README.md
+++ b/compiled_starters/cpp/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `src/main.cpp`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/csharp/README.md
+++ b/compiled_starters/csharp/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `src/Server.cs`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/elixir/README.md
+++ b/compiled_starters/elixir/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `lib/main.ex`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/go/README.md
+++ b/compiled_starters/go/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `app/main.go`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/java/README.md
+++ b/compiled_starters/java/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in
-`src/main/java/Main.java`. Study and uncomment the relevant code, and push your
-changes to pass the first stage:
+`src/main/java/Main.java`. Study and uncomment the relevant code, and then run
+the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/javascript/README.md
+++ b/compiled_starters/javascript/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `app/main.js`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/kotlin/README.md
+++ b/compiled_starters/kotlin/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in
-`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and push
-your changes to pass the first stage:
+`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and then
+run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/php/README.md
+++ b/compiled_starters/php/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `app/main.php`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/python/README.md
+++ b/compiled_starters/python/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `app/main.py`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/ruby/README.md
+++ b/compiled_starters/ruby/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `app/main.rb`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `src/main.rs`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/typescript/README.md
+++ b/compiled_starters/typescript/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `app/main.ts`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/zig/README.md
+++ b/compiled_starters/zig/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `src/main.zig`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/c/01-ux2/code/README.md
+++ b/solutions/c/01-ux2/code/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `src/main.c`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/cpp/01-ux2/code/README.md
+++ b/solutions/cpp/01-ux2/code/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `src/main.cpp`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/csharp/01-ux2/code/README.md
+++ b/solutions/csharp/01-ux2/code/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `src/Server.cs`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/elixir/01-ux2/code/README.md
+++ b/solutions/elixir/01-ux2/code/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `lib/main.ex`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/go/01-ux2/code/README.md
+++ b/solutions/go/01-ux2/code/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `app/main.go`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/java/01-ux2/code/README.md
+++ b/solutions/java/01-ux2/code/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in
-`src/main/java/Main.java`. Study and uncomment the relevant code, and push your
-changes to pass the first stage:
+`src/main/java/Main.java`. Study and uncomment the relevant code, and then run
+the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/javascript/01-ux2/code/README.md
+++ b/solutions/javascript/01-ux2/code/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `app/main.js`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/kotlin/01-ux2/code/README.md
+++ b/solutions/kotlin/01-ux2/code/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in
-`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and push
-your changes to pass the first stage:
+`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and then
+run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/php/01-ux2/code/README.md
+++ b/solutions/php/01-ux2/code/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `app/main.php`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/python/01-ux2/code/README.md
+++ b/solutions/python/01-ux2/code/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `app/main.py`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/ruby/01-ux2/code/README.md
+++ b/solutions/ruby/01-ux2/code/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `app/main.rb`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/rust/01-ux2/code/README.md
+++ b/solutions/rust/01-ux2/code/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `src/main.rs`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/typescript/01-ux2/code/README.md
+++ b/solutions/typescript/01-ux2/code/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `app/main.ts`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/zig/01-ux2/code/README.md
+++ b/solutions/zig/01-ux2/code/README.md
@@ -15,12 +15,11 @@ various record types (A, AAAA, CNAME, etc) and more.
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `src/main.zig`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/starter_templates/all/code/README.md
+++ b/starter_templates/all/code/README.md
@@ -10,11 +10,10 @@ In this challenge, you'll build a DNS server that's capable of parsing and creat
 # Passing the first stage
 
 The entry point for your `your_program.sh` implementation is in `{{ user_editable_file }}`. Study and uncomment the relevant code, and
-push your changes to pass the first stage:
+then run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!


### PR DESCRIPTION
https://linear.app/codecrafters/issue/CC-2159/replace-git-commands-in-readmes-as-cc-submit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that adjust submission instructions without affecting any runtime code or build logic.
> 
> **Overview**
> Updates starter and solution README instructions (and the shared `starter_templates/all` template) to **stop recommending `git commit`/`git push` for passing the first stage** and instead instruct users to run `codecrafters submit` to execute server-side tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e04fb2c00d87d80b1cb911be689cfb003c6c3858. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->