### PR TITLE
Remove incorrect statement in base-02-tz1.md

### DIFF
--- a/stage_descriptions/base-02-tz1.md
+++ b/stage_descriptions/base-02-tz1.md
@@ -13,7 +13,7 @@ The header section of a DNS message contains the following fields: (we've also i
 | Query/Response Indicator (QR)     | 1 bit   | 1 for a reply packet, 0 for a question packet. <br />**Expected value**: 1.                                          |
 | Operation Code (OPCODE)           | 4 bits  | Specifies the kind of query in a message. <br />**Expected value**: 0.                                               |
 | Authoritative Answer (AA)         | 1 bit   | 1 if the responding server "owns" the domain queried, i.e., it's authoritative. <br />**Expected value**: 0.         |
-| Truncation (TC)                   | 1 bit   | 1 if the message is larger than 512 bytes. Always 0 in UDP responses. <br />**Expected value**: 0.                   |
+| Truncation (TC)                   | 1 bit   | 1 if the message is larger than 512 bytes.<br />**Expected value**: 0.                   |
 | Recursion Desired (RD)            | 1 bit   | Sender sets this to 1 if the server should recursively resolve this query, 0 otherwise. <br />**Expected value**: 0. |
 | Recursion Available (RA)          | 1 bit   | Server sets this to 1 to indicate that recursion is available. <br />**Expected value**: 0.                          |
 | Reserved (Z)                      | 3 bits  | Used by DNSSEC queries. At inception, it was reserved for future use. <br />**Expected value**: 0.                   |


### PR DESCRIPTION
Context:

https://secure.helpscout.net/conversation/3334603901/13285?viewId=8414074

<img width="1198" height="126" alt="image" src="https://github.com/user-attachments/assets/2906c326-9dc9-4bc5-b597-b0015f05342c" />

---

Fact check:

The statement "Always 0 in UDP responses" is too absolute. It can theoretically be 1 when the Truncation bit needs to be set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4aadfe41f73ef60c987501325ecb3256fbb99877. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->